### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/rg-engineering/ioBroker.heatingcontrol"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "3.0.4",


### PR DESCRIPTION
As you removed node 16 tests, this adapter requires node 18 minimum now.
Please check this PR an merge to update engines clause.