### PR TITLE
fix(logging): 'userTage' -> 'userTag' in discord-not-configured error

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -489,7 +489,7 @@ function sendNotificationDiscord() {
 
                     });
             } else {
-                parentAdapter.log.error("no discord userTage configured");
+                parentAdapter.log.error("no discord userTag configured");
             }
         } else if (parentAdapter.config.discordTarget == "UserId") {
             if (parentAdapter.config.discordUserId != null && parentAdapter.config.discordUserId.length > 1) {


### PR DESCRIPTION
Fixes #808. Single-character fix in `lib/logging.js:492` — error message referred to `userTage` but the actual config key is `userTag` (matching line 481 `userTag: parentAdapter.config.discordUserTag`).

```diff
- parentAdapter.log.error("no discord userTage configured");
+ parentAdapter.log.error("no discord userTag configured");
```

Error-string only; no logic impact.