### PR TITLE
Put the wrapped FireplaceModeActive description into one cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Features:
 | PartyNow            | decrease temperature because it's becoming hot'            | decrease current profile temperature by Profiles.0.room.relative.PartyDecrease          | set target to Profiles.0.room.absolute.PartyDecrease          | 
 | Present             | we are present, if we are not present decrease temperature | decrease current profile temperature by Profiles.0.room.relative.AbsentDecrease         | set target to Profiles.0.room.absolute.AbsentDecrease         | 
 | VacationAbsent	  | we are absent, so decrease also on weekend                 | decrease current profile temperature by Profiles.0.room.relative.VacationAbsentDecrease | set target to Profiles.0.room.absolute.VacationAbsentDecrease | 
-| FireplaceModeActive | decrease temperature bacause you use a fireplace, will be  | decrease current profile temperature by Profiles.0.room.relative.FireplaceModeDecrease  | set target to Profiles.0.room.absolute.FireplaceModeDecrease  | 
-|                     | reseted automatically at adjustable time
+| FireplaceModeActive | decrease temperature bacause you use a fireplace, will be reseted automatically at adjustable time | decrease current profile temperature by Profiles.0.room.relative.FireplaceModeDecrease  | set target to Profiles.0.room.absolute.FireplaceModeDecrease  | 
 
 
 * Datapoints only available if "General Profile Settings, temperature lowering" is set


### PR DESCRIPTION
The description of `FireplaceModeActive` is wrapped onto a second line:

```
| FireplaceModeActive | decrease temperature bacause you use a fireplace, will be  | ... | ... |
|                     | reseted automatically at adjustable time
```

A markdown table row cannot be continued on the next line — GitHub renders the second line as a separate, half-empty row, and the sentence "…will be reseted automatically at adjustable time" is torn apart.

This puts the sentence back into one cell and removes the continuation line. Nothing else changes.

### Why

The README is imported into the ioBroker documentation site (https://www.iobroker.net/#en/adapters/adapterref/iobroker.heatingcontrol/README.md). The import parses the table rather than only rendering it, so the stray row broke the table there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuQKZiCCEE2YwCT74cpqQR
